### PR TITLE
Fix link errors and some config inssues

### DIFF
--- a/android/3rd_party/BottomSheet/build.gradle
+++ b/android/3rd_party/BottomSheet/build.gradle
@@ -25,4 +25,10 @@ android {
   defaultConfig {
     minSdkVersion propMinSdkVersion.toInteger()
   }
+
+  buildTypes {
+    debug {}
+    release {}
+    beta {}
+  }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -140,7 +140,7 @@ android {
       cmake {
         cppFlags '-fexceptions', '-frtti', '-m32'
         cFlags '-ffunction-sections', '-fdata-sections', '-Wno-extern-c-compat', '-m32'
-        arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static', "-DOS=$osName"
+        arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static', "-DOS=$osName", "-DSKIP_TESTS=ON"
       }
     }
 
@@ -409,9 +409,11 @@ def buildTypes = [[ndkType: 'release', cppType: "production", flags: propRelease
 def unalignedFonts = "${propObbFontsOutput}.unaligned"
 def unalignedWorlds = "${propObbWorldsOutput}.unaligned"
 
-task obbClean(type: Delete) << {
-  [propObbFontsOutput, propObbWorldsOutput, unalignedFonts, unalignedWorlds].each { file ->
-    delete file
+task obbClean(type: Delete) {
+  doLast {
+    [propObbFontsOutput, propObbWorldsOutput, unalignedFonts, unalignedWorlds].each { file ->
+      delete file
+    }
   }
 }
 


### PR DESCRIPTION
Warnings `registerResGeneratingTask` is thrown from fabric and crashlytic plugins:
```
10:33:03.338 [QUIET] [system.out] registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
10:33:03.339 [DEBUG] [org.gradle.model.internal.registry.DefaultModelRegistry] Project : - Registering model element 'tasks.crashlyticsGenerateSymbolsAppChinaDebug' (hidden = false)
```
Besides this all is building successfully:
![image](https://user-images.githubusercontent.com/814614/34404521-1d4ac908-ebbf-11e7-9b15-a6078a2ea4f6.png)
